### PR TITLE
README: Use stable release of wrangler 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## pyrox
 
-Proxy that runs on [CloudFlare Workers](https://workers.dev).
+Proxy that runs on [Cloudflare Workers](https://workers.dev).
 
 #### Setup
 
-1. Install wrangler2 (atm in beta). `npm install wrangler@beta`.
+1. Install wrangler2. `npm install wrangler`.
 2. Generate a public Ed25519 key, exported under SPKI mode with PEM formatting. Should look like this:
 
 ```


### PR DESCRIPTION
- Fixes the atrocious stylisation "CloudFlare" - Cloudflare has been the correct styalisation for years.
- Removes the beta note for wrangler and installs the package directly since it has now released.

Wrangler release: https://github.com/cloudflare/wrangler2/releases/tag/wrangler%402.0.0
Announcement pending.

You could also `npm install wrangler@2.0.0` if you wanted, but it would have to be updated constantly.